### PR TITLE
Preparing for npm registry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-canvas-draw",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-canvas-draw-annotations",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "A simple yet powerful canvas-drawing component for React.",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@delia-m/react-canvas-draw",
+  "name": "react-canvas-draw-annotations",
   "version": "1.2.1",
   "description": "A simple yet powerful canvas-drawing component for React.",
   "main": "lib/index.js",


### PR DESCRIPTION
The package name needed to be outside the 'delia-m' scope (free npm version).
